### PR TITLE
fix: fixed announce highscore

### DIFF
--- a/src/main/java/dev/slne/surf/parkour/parkour/Parkour.kt
+++ b/src/main/java/dev/slne/surf/parkour/parkour/Parkour.kt
@@ -98,8 +98,8 @@ data class Parkour(
             player.teleportAsync(Location(world, respawn.x, respawn.y, respawn.z)).await()
         }
 
-        updateHighscore(player)
         announceNewHighscore(player)
+        updateHighscore(player)
 
         currentPoints.removeInt(uuid)
         latestJumps.remove(uuid)


### PR DESCRIPTION
before, the players highscore was updated before it was announced. The highscore will only be announced when the currentpointf of the players are higher than the players highscore. The highscore was already updated to the currenpoints and so the highscore is equal to the currentpoints in the announcement check causing the highscore to not be announced to the player